### PR TITLE
Easier building/developing of ptychopy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,138 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/

--- a/README.md
+++ b/README.md
@@ -1,34 +1,45 @@
 # ptychopy
 
-1 Need to install python3 to run the GUI and ptychopy, other needed library is in requirement.txt.(Tested OS RHEL 6.0, 7.0)
+1. Need to install python3 to run the GUI and ptychopy, other needed library is
+   in requirement.txt.(Tested OS RHEL 6.0, 7.0)
 
-2 Recommend conda virtual environment, for example
+2. Recommend conda virtual environment, for example
 
-  conda create -n py34 python=3.4
+ ```
+ conda create -n py34 python=3.4
+ ```
 
-3 Activate the virtual environment
+3. Activate the virtual environment
 
-  source activate py34
+ ```
+ source activate py34
+ ```
 
-4 Set the cuda computing based on your GPU, for example
+4. Set the cuda computing based on your GPU. For example the 2080 Ti has
+   compute capability 7.5.
 
-  export CUDACOMPUTE=7.5 (2080ti)
-  The GPU computing capability number can be found on the nvidia website
+ ```
+ export CUDACOMPUTE=7.5
+ ```
 
-5 To install and build the python package, set another two environment varialbe
-  HDF5_BASE and CUDAHOME, which point to the installed path of the CUDA and HDF5
-  library. Then just call the following
-  
-  ./install.sh
+  The GPU computing capability number can be found on the [NVidia website](https://developer.nvidia.com/cuda-gpus)
 
-6 For testing, you can use testPTY.py or testMpty.py
+5. To install and build the python package, set another two environment
+   variable HDF5_BASE and CUDAHOME, which point to the installed path of the
+   CUDA and HDF5 library. Then just call the following
 
-  python testPTY.py
-  
+ ```
+ ./install.sh
+ ```
 
+6. For testing, you can use testPTY.py or testMpty.py
+
+ ```
+ python testPTY.py
+ ```
 
 # parameters
-  
+
   Name | Type | Description | Default
 :------------: | :-------------: | :------------: | :------------:
 jobID | string  | An identifying tag to the reconstruction run | ``

--- a/setup.py
+++ b/setup.py
@@ -185,19 +185,6 @@ else:
 
 with open('./requirements.txt','r') as f_requirements:
     requirements = f_requirements.readlines()
-    for requirement in requirements:
-        try:
-            pkg_resources.require(requirement.strip().replace('==', '>='))
-        except pkg_resources.VersionConflict:
-            msg = 'Python package requirement not satisfied: ' + requirement
-            msg += '\nsuggest using this command:'
-            msg += '\n\tpip install -r requirements.txt'
-            raise pkg_resources.VersionConflict(msg)
-        except pkg_resources.DistributionNotFound:
-            msg = 'Python package requirement not satisfied: ' + requirement
-            msg += '\nsuggest using this command:'
-            msg += '\n\tpip install -r requirements.txt'
-            raise pkg_resources.VersionConflict(msg)
 
 # Create ptychopy.so
 extptychopy = Extension(name='ptychopy',

--- a/setup.py
+++ b/setup.py
@@ -243,7 +243,7 @@ extptychopy = Extension(name='ptychopy',
             HDF5['lib'],
             ],
         runtime_library_dirs=[CUDA['lib']],
-        extra_link_args = ['-lcudart', '-lcurand', '-lcufft', '-lcublas', '-lGL', '-lhdf5', '-lhdf5_cpp', '-lpthread'],
+        extra_link_args = ['-lcudart', '-lcurand', '-lcufft', '-lcublas', '-lhdf5', '-lhdf5_cpp', '-lpthread'],
         extra_compile_args={
             'nvcc': ['-Xcompiler', '-fpic', '-O3', '-gencode=arch=compute_{:s},code=sm_{:s}'.format(CUDA['compute'],CUDA['sm'])],
             'gcc': ['-DEPIE_HDF5',  '-fpic', '-DHAVE_HDF5'],


### PR DESCRIPTION
In order make building/developing easier, I have eased some of the strict build-time requirements such as python dependency checking (which is not required to compile) and removing libGL as a linked-library (as far as I can tell it is not used). Also formatted the README.